### PR TITLE
Refactor Candidates to not use BitVec

### DIFF
--- a/src/candidates.rs
+++ b/src/candidates.rs
@@ -1,83 +1,202 @@
-use std::ops::BitOrAssign;
-
-use bit_vec::BitVec;
+use std::{fmt::{Debug, Formatter, Result}, ops::{BitOr, BitOrAssign, Shl}};
 
 /// Candidates Bitset
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Candidates(BitVec);
+#[derive(Clone, PartialEq, Eq)]
+pub struct Candidates(u16);
 
 impl Candidates {
+    const ALL_MASK: u16 = 0b111111111;
+
     /// Creates a new candidates with all candidates
-    pub fn all() -> Candidates {
-        Candidates(BitVec::from_elem(10, true))
+    pub fn all() -> Self {
+        Candidates(0b111111111)
     }
 
     /// Creates a new empty candidates set
-    pub fn empty() -> Candidates {
-        Candidates(BitVec::from_elem(10, false))
+    pub fn empty() -> Self {
+        Candidates(0b000000000)
+    }
+
+    /// Crates a new empty candidates set from value
+    pub fn from(bits: u16) -> Self {
+        Candidates(bits)
     }
 
     /// Returns true if the candidates set is empty
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        (self.0 & Self::ALL_MASK) == 0
     }
 
     /// Sets the given candidate
     #[inline(always)]
     pub fn set(&mut self, candidate: u8) {
-        self.0.set(candidate as usize, true);
+        assert!(candidate >= 1);
+        self.0 |= 1_u16.shl(candidate - 1)
     }
 
     /// Unsets the given candidate
     #[inline(always)]
     pub fn unset(&mut self, candidate: u8) {
-        self.0.set(candidate as usize, false);
+        assert!(candidate >= 1);
+        self.0 &= !1_u16.shl(candidate - 1);
     }
 
     /// Returns true if candidate is set
     #[inline(always)]
     pub fn get(&self, candidate: u8) -> bool {
-        self.0.get(candidate as usize).unwrap_or(false)
+        assert!(candidate >= 1);
+        self.0 & 1_u16.shl(candidate - 1) > 0
     }
 
-    /// Returns an iterator over all candidates
+    /// Returns an iterator over all set candidates
     pub fn iter(&self) -> impl Iterator<Item = u8> + '_ {
-        self.0
-            .iter()
-            .enumerate()
-            .filter(|(_index, v)| *v)
-            .map(|(index, _)| index as u8)
+        (0u16..9)
+            .filter(move |index| (self.0 & 1u16.shl(index) > 0))
+            .map(|index| (index + 1) as u8)
     }
 
     /// Returns the number of set candidates
     #[inline(always)]
     pub fn count(&self) -> usize {
-        self.0.iter().filter(|v| *v).count()
+        self.0.count_ones() as usize
     }
 
     /// Returns the intersection of two bit sets
     pub fn intersect(lhs: &Self, rhs: &Self) -> Self {
         let mut lhs = lhs.clone();
-        lhs.0.and(&rhs.0);
+        lhs.0 &= rhs.0;
         lhs
     }
+}
 
-    /// Returns the difference of two bit sets
-    pub fn difference(lhs: &Self, rhs: &Self) -> Self {
-        let mut lhs = lhs.clone();
-        lhs.0.difference(&rhs.0);
-        lhs
+impl Debug for Candidates {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let candidates = self.iter().collect::<Vec<_>>();
+        write!(f, "{:?}", candidates)
     }
+}
 
-    /// Updates this BitVec combining the other candidates using logical "or".
-    pub fn or(&mut self, rhs: &Self) -> bool {
-        self.0.or(&rhs.0)
+impl BitOr for Candidates {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Candidates(self.0 | rhs.0)
     }
 }
 
 impl BitOrAssign for Candidates {
     fn bitor_assign(&mut self, rhs: Self) {
-        self.or(&rhs);
+        self.0 |= rhs.0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Candidates;
+
+    #[test]
+    fn is_empty() {
+        let candidates = Candidates::empty();
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn all_candidates_set() {
+        let candidates = Candidates::all();
+        assert!(!candidates.is_empty());
+        assert_eq!(9, candidates.count());
+    }
+
+    #[test]
+    fn from_candidates() {
+        let candidates = Candidates::from(0b0110011);
+        assert!(!candidates.is_empty());
+        assert_eq!(4, candidates.count());
+    }
+
+    #[test]
+    fn set_single_candidate() {
+        let mut candidates = Candidates::empty();
+        candidates.set(4);
+        assert!(!candidates.is_empty());
+        assert!(candidates.get(4));
+        assert_eq!(1, candidates.count());
+    }
+
+    #[test]
+    fn unset_single_candidate() {
+        let mut candidates = Candidates::from(0b000111000);
+        candidates.unset(5);
+        assert!(!candidates.is_empty());
+        assert_eq!(2, candidates.count());
+        assert_eq!(
+            vec![4, 6],
+            candidates.iter().collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn unset_same_bit_multiple_times() {
+        let mut candidates = Candidates::from(0b000111000);
+        candidates.unset(5);
+        candidates.unset(5);
+        assert!(!candidates.is_empty());
+        assert_eq!(2, candidates.count());
+        assert_eq!(
+            vec![4, 6],
+            candidates.iter().collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn set_multiple_candidates() {
+        let mut candidates = Candidates::empty();
+        candidates.set(1);
+        candidates.set(3);
+        candidates.set(9);
+
+        assert_eq!(3, candidates.count());
+        assert!(candidates.get(3));
+        assert!(!candidates.get(4));
+    }
+
+    #[test]
+    fn candidates_iter() {
+        let mut candidates = Candidates::empty();
+        candidates.set(1);
+        candidates.set(3);
+        candidates.set(9);
+
+        assert_eq!(
+            vec![1, 3, 9],
+            candidates.iter().collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn intersect_candidates() {
+        let lhs = Candidates::from(0b101101);
+        let rhs = Candidates::from(0b011100);
+
+        let result = Candidates::intersect(&lhs, &rhs);
+        assert_eq!(2, result.count());
+        assert_eq!(
+            vec![3, 4],
+            result.iter().collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn candidates_or() {
+        let lhs = Candidates::from(0b111000);
+        let rhs = Candidates::from(0b011010);
+
+        let result = lhs | rhs;
+        assert_eq!(4, result.count());
+        assert_eq!(
+            vec![2, 4, 5, 6],
+            result.iter().collect::<Vec<_>>(),
+        );
     }
 }

--- a/src/strategy/algorithms/hidden_single.rs
+++ b/src/strategy/algorithms/hidden_single.rs
@@ -30,6 +30,7 @@ impl HiddenSingle {
             let mut step = Step::new();
             step.set_digit(cell_index, digit);
 
+            println!("::: CANDIDATES: {:?}", sudoku.get(cell_index));
             for c in sudoku.get(cell_index).candidates().iter() {
                 if c != digit {
                     step.eliminate_candidate(cell_index, c);

--- a/src/sudoku.rs
+++ b/src/sudoku.rs
@@ -137,22 +137,24 @@ impl Sudoku {
     /// **Note** this will not check or validate the candidates
     ///
     pub fn init_candidates(&mut self) {
-        for row in 0..9 {
-            for col in 0..9 {
-                let index = (col + row * Self::ROWS) as usize;
-
-                if self.cells[index].is_empty() {
-                    let candidates = self.get_house(index).fold(
-                        Candidates::all(),
-                        |mut candidates, neighbor| {
+        println!("INIT CANDIDATES");
+        for index in 0..Self::NUM_FIELDS {
+            if self.cells[index].is_empty() {
+                let neighbors = self.get_house(index);
+                let candidates = neighbors.fold(
+                    Candidates::all(),
+                    |mut candidates, neighbor| {
+                        if neighbor.is_digit() {
+                            println!("--- UNSET: {} - {}", neighbor.index(), neighbor.digit());
                             candidates.unset(neighbor.digit());
-                            candidates
-                        },
-                    );
+                        }
+                        candidates
+                    },
+                );
 
-                    let cell = &mut self.cells[index];
-                    cell.set_candidates(candidates);
-                }
+                println!(" :: {} - candidates: {:?}", index, candidates);
+                let cell = &mut self.cells[index];
+                cell.set_candidates(candidates);
             }
         }
     }


### PR DESCRIPTION
The `Candidates` struct replaces the `BitVec` with a plain `u16`.

* add tests